### PR TITLE
Auth: implement useReconcileUser hook and use an Axios instance

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,4 +1,3 @@
-import axios from "axios";
 import Login from "components/Authentication/Login/Login";
 import Private from "components/Authentication/Private";
 import Register from "components/Authentication/Register/Register";
@@ -10,11 +9,6 @@ import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
 import { Wrapper } from "./App.style";
 const NewTickets = lazy(() => import("components/NewTicket/NewTickets/NewTickets"));
-
-// TODO: dev-only baseURL - on prod we'd want to map this to the docker service
-// (0.0.0.0:5000??? http://server:5000??? maybe even just the domain, like trade.seerden.dev/)
-axios.defaults.baseURL = "http://localhost:5000";
-axios.defaults.withCredentials = true;
 
 const App = () => {
 	useReconcileSession();

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,18 +18,28 @@ axios.defaults.withCredentials = true;
 
 const App = () => {
 	const { user, login, logout } = useAuth();
+
+	// Get current user session from backend. If user doesn't match with what
+	// client believes it should be, log in or out, depending on response.
 	useEffect(() => {
 		(async function() {
-			// get auth/me
-			const { data } = await axios.get<any, { data?: { username?: string } }>("/auth/me");
-			// if user matches, don't do anything
-			// if no user returned, logout()
-			if (!data?.username) {
+			try {
+				const { data } = await axios.get("/auth/me");
+
+				// If user matches, don't do anything
+				// If no user returned, logout()
+				if (!data?.username) {
+					logout();
+				}
+				// If user in session doesn't match user on client, log in with user
+				// from session.
+				if (data?.username !== user.username) {
+					login({ username: data.username });
+				}
+			} catch (error) {
+				// Either user isn't logged in (response 401), or something else
+				// went wrong. Either way, we should log out.
 				logout();
-			}
-			// if different user returned, login with that user
-			if (data?.username !== user.username) {
-				login({ username: data.username });
 			}
 		})();
 	}, []);

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,8 +4,8 @@ import Private from "components/Authentication/Private";
 import Register from "components/Authentication/Register/Register";
 import Navigation from "components/Navigation/Navigation";
 import { theme } from "helpers/theme/theme";
-import { useAuth } from "hooks/auth/useAuth";
-import { lazy, Suspense, useEffect } from "react";
+import useReconcileSession from "hooks/auth/useReconcileSession";
+import { lazy, Suspense } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
 import { Wrapper } from "./App.style";
@@ -17,32 +17,7 @@ axios.defaults.baseURL = "http://localhost:5000";
 axios.defaults.withCredentials = true;
 
 const App = () => {
-	const { user, login, logout } = useAuth();
-
-	// Get current user session from backend. If user doesn't match with what
-	// client believes it should be, log in or out, depending on response.
-	useEffect(() => {
-		(async function() {
-			try {
-				const { data } = await axios.get("/auth/me");
-
-				// If user matches, don't do anything
-				// If no user returned, logout()
-				if (!data?.username) {
-					logout();
-				}
-				// If user in session doesn't match user on client, log in with user
-				// from session.
-				if (data?.username !== user.username) {
-					login({ username: data.username });
-				}
-			} catch (error) {
-				// Either user isn't logged in (response 401), or something else
-				// went wrong. Either way, we should log out.
-				logout();
-			}
-		})();
-	}, []);
+	useReconcileSession();
 
 	return (
 		<div className="App">

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,7 +4,7 @@ import Private from "components/Authentication/Private";
 import Register from "components/Authentication/Register/Register";
 import Navigation from "components/Navigation/Navigation";
 import { theme } from "helpers/theme/theme";
-import { lazy, Suspense } from "react";
+import { lazy, Suspense, useEffect } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
 import { Wrapper } from "./App.style";
@@ -16,6 +16,15 @@ axios.defaults.baseURL = "http://localhost:5000";
 axios.defaults.withCredentials = true;
 
 const App = () => {
+	useEffect(() => {
+		(async function() {
+			// get auth/me
+			// if user matches, don't do anything
+			// if no user returned, logout()
+			// if different user returned, login with that user
+		})();
+	}, []);
+
 	return (
 		<div className="App">
 			<BrowserRouter>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -4,6 +4,7 @@ import Private from "components/Authentication/Private";
 import Register from "components/Authentication/Register/Register";
 import Navigation from "components/Navigation/Navigation";
 import { theme } from "helpers/theme/theme";
+import { useAuth } from "hooks/auth/useAuth";
 import { lazy, Suspense, useEffect } from "react";
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { ThemeProvider } from "styled-components";
@@ -16,12 +17,20 @@ axios.defaults.baseURL = "http://localhost:5000";
 axios.defaults.withCredentials = true;
 
 const App = () => {
+	const { user, login, logout } = useAuth();
 	useEffect(() => {
 		(async function() {
 			// get auth/me
+			const { data } = await axios.get<any, { data?: { username?: string } }>("/auth/me");
 			// if user matches, don't do anything
 			// if no user returned, logout()
+			if (!data?.username) {
+				logout();
+			}
 			// if different user returned, login with that user
+			if (data?.username !== user.username) {
+				login({ username: data.username });
+			}
 		})();
 	}, []);
 

--- a/client/src/components/Authentication/Login/useLogin.ts
+++ b/client/src/components/Authentication/Login/useLogin.ts
@@ -1,4 +1,4 @@
-import axios from "axios";
+import useAxios from "helpers/api/axios-instance";
 import { useAuth } from "hooks/auth/useAuth";
 import { useState } from "react";
 import { useNavigate } from "react-router";
@@ -24,6 +24,7 @@ function useLogin() {
 	const [user, setUser] = useState<User>(emptyUser);
 	const { login, user: currentUser, logout } = useAuth();
 	const navigate = useNavigate();
+	const axiosInstance = useAxios();
 
 	function updateUser(
 		e: React.ChangeEvent<HTMLInputElement> /* @todo: change event type? */
@@ -47,9 +48,12 @@ function useLogin() {
 		try {
 			/* @note have to destructure `user` so that passport.authenticate() on the backend works properly. */
 			// @see  https://github.com/Seerden/trade/issues/12
-			const { data } = await axios.post<any, { data: UserResponse }>("/auth/login", {
-				...user
-			});
+			const { data } = await axiosInstance.post<any, { data: UserResponse }>(
+				"/auth/login",
+				{
+					...user
+				}
+			);
 			const { username, created_at } = data;
 			/**
 			 * @todo:
@@ -70,7 +74,7 @@ function useLogin() {
 		e.preventDefault();
 
 		try {
-			const { data } = await axios.post("/auth/logout");
+			const { data } = await axiosInstance.post("/auth/logout");
 			if (data.success === true) {
 				logout();
 				navigate("/");

--- a/client/src/components/Charts/CandleChart/CandleChart.tsx
+++ b/client/src/components/Charts/CandleChart/CandleChart.tsx
@@ -1,26 +1,26 @@
 import { useEffect, useRef } from "react";
 
 export default function CandleChart(): JSX.Element {
-    const canvasRef = useRef<HTMLCanvasElement>();
+	const canvasRef = useRef<HTMLCanvasElement>();
 
-    /**
-     * On mount, grab data.
-     * This could also be passed from somewhere (as a prop), or be available as
-     * a piece of accessible (global) state.
-     */
-    useEffect(() => {
-        // fetch data
-    }, []);
+	/**
+	 * On mount, grab data.
+	 * This could also be passed from somewhere (as a prop), or be available as
+	 * a piece of accessible (global) state.
+	 */
+	useEffect(() => {
+		// fetch data
+	}, []);
 
-    useEffect(() => {
-        const canvas = canvasRef.current;
+	useEffect(() => {
+		const canvas = canvasRef.current;
 
-        if (canvas) {
-            const context = canvas?.getContext("2d");
-            context.fillStyle = "#000000";
-            context.fillRect(0, 0, context.canvas.width, context.canvas.height);
-        }
-    }, []);
+		if (canvas) {
+			const context = canvas?.getContext("2d");
+			context.fillStyle = "#000000";
+			context.fillRect(0, 0, context.canvas.width, context.canvas.height);
+		}
+	}, []);
 
-    return <canvas ref={canvasRef} width={750} height={350} />;
+	return <canvas ref={canvasRef} width={750} height={350} />;
 }

--- a/client/src/helpers/api/axios-instance.ts
+++ b/client/src/helpers/api/axios-instance.ts
@@ -8,7 +8,8 @@ export default function useAxios() {
 		// (0.0.0.0:5000??? http://server:5000??? maybe even just the domain, like trade.seerden.dev/)
 		baseURL: "http://localhost:5000",
 		withCredentials: true,
-		params: { username: user?.username }
+		// Add username query parameter to every request
+		...(user?.username && { params: { username: user?.username } })
 	});
 
 	return axiosInstance;

--- a/client/src/helpers/api/axios-instance.ts
+++ b/client/src/helpers/api/axios-instance.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+import { useAuth } from "hooks/auth/useAuth";
+
+export default function useAxios() {
+	const { user } = useAuth();
+	const axiosInstance = axios.create({
+		// TODO: dev-only baseURL - on prod we'd want to map this to the docker service
+		// (0.0.0.0:5000??? http://server:5000??? maybe even just the domain, like trade.seerden.dev/)
+		baseURL: "http://localhost:5000",
+		withCredentials: true,
+		params: { username: user?.username }
+	});
+
+	return axiosInstance;
+}

--- a/client/src/hooks/auth/useReconcileSession.tsx
+++ b/client/src/hooks/auth/useReconcileSession.tsx
@@ -19,7 +19,7 @@ export default function useReconcileSession() {
 				}
 				// If user in session doesn't match user on client, log in with user
 				// from session.
-				if (data?.username !== user.username) {
+				if (data?.username !== user.username || !user?.username) {
 					login({ username: data.username });
 				}
 			} catch (error) {

--- a/client/src/hooks/auth/useReconcileSession.tsx
+++ b/client/src/hooks/auth/useReconcileSession.tsx
@@ -1,0 +1,32 @@
+import axios from "axios";
+import { useEffect } from "react";
+import { useAuth } from "./useAuth";
+
+export default function useReconcileSession() {
+	const { user, login, logout } = useAuth();
+
+	// Get current user session from backend. If user doesn't match with what
+	// client believes it should be, log in or out, depending on response.
+	useEffect(() => {
+		(async function() {
+			try {
+				const { data } = await axios.get<{ username?: string }>("/auth/me");
+
+				// If user matches, don't do anything
+				// If no user returned, logout()
+				if (!data?.username) {
+					logout();
+				}
+				// If user in session doesn't match user on client, log in with user
+				// from session.
+				if (data?.username !== user.username) {
+					login({ username: data.username });
+				}
+			} catch (error) {
+				// Either user isn't logged in (response 401), or something else
+				// went wrong. Either way, we should log out.
+				logout();
+			}
+		})();
+	}, []);
+}

--- a/client/src/hooks/auth/useReconcileSession.tsx
+++ b/client/src/hooks/auth/useReconcileSession.tsx
@@ -6,8 +6,9 @@ export default function useReconcileSession() {
 	const { user, login, logout } = useAuth();
 	const axiosInstance = useAxios();
 
-	// Get current user session from backend. If user doesn't match with what
-	// client believes it should be, log in or out, depending on response.
+	// Get current user session from backend. If user from client isn't equal to
+	// user from backend, then log in with user from backend, or log out,
+	// depending on the backend response.
 	useEffect(() => {
 		(async function() {
 			try {
@@ -18,14 +19,13 @@ export default function useReconcileSession() {
 				if (!data?.username) {
 					logout();
 				}
-				// If user in session doesn't match user on client, log in with user
-				// from session.
+				// If session user != client user, log in with session user.
 				if (data?.username !== user.username || !user?.username) {
 					login({ username: data.username });
 				}
 			} catch (error) {
-				// Either user isn't logged in (response 401), or something else
-				// went wrong. Either way, we should log out.
+				// No user in session (response 401), or something else went wrong.
+				// Either way, log out.
 				logout();
 			}
 		})();

--- a/client/src/hooks/auth/useReconcileSession.tsx
+++ b/client/src/hooks/auth/useReconcileSession.tsx
@@ -1,16 +1,17 @@
-import axios from "axios";
+import useAxios from "helpers/api/axios-instance";
 import { useEffect } from "react";
 import { useAuth } from "./useAuth";
 
 export default function useReconcileSession() {
 	const { user, login, logout } = useAuth();
+	const axiosInstance = useAxios();
 
 	// Get current user session from backend. If user doesn't match with what
 	// client believes it should be, log in or out, depending on response.
 	useEffect(() => {
 		(async function() {
 			try {
-				const { data } = await axios.get<{ username?: string }>("/auth/me");
+				const { data } = await axiosInstance.get<{ username?: string }>("/auth/me");
 
 				// If user matches, don't do anything
 				// If no user returned, logout()

--- a/server/api/helpers/auth/user.ts
+++ b/server/api/helpers/auth/user.ts
@@ -5,27 +5,27 @@ import { BackendApiObject as API } from "../../../database/pools/query-objects";
  * Fetch user from database, by username
  */
 export async function getUser(username: string) {
-    return await API.query({
-        text: "select username, created_at, password from users where username = $1",
-        values: [username],
-    });
+	return await API.query({
+		text: "select username, created_at, user_id from users where username = $1",
+		values: [username],
+	});
 }
 
 type NewUser = {
-    username: string;
-    password: string;
+	username: string;
+	password: string;
 };
 
 export async function createUser({ username, password }: NewUser) {
-    const hashedPassword = await hash(password, 10);
+	const hashedPassword = await hash(password, 10);
 
-    // TODO: what happens if we try to insert a user with a username that's
-    // already taken?
-    return await API.query({
-        text: `
+	// TODO: what happens if we try to insert a user with a username that's
+	// already taken?
+	return await API.query({
+		text: `
             insert into users (username, password) values ($1, $2) 
             returning username, user_id, created_at
         `,
-        values: [username, hashedPassword],
-    });
+		values: [username, hashedPassword],
+	});
 }

--- a/server/api/helpers/auth/user.ts
+++ b/server/api/helpers/auth/user.ts
@@ -6,7 +6,7 @@ import { BackendApiObject as API } from "../../../database/pools/query-objects";
  */
 export async function getUser(username: string) {
 	return await API.query({
-		text: "select username, created_at, user_id from users where username = $1",
+		text: "select username, created_at, password, user_id from users where username = $1",
 		values: [username],
 	});
 }

--- a/server/api/routers/auth-router.ts
+++ b/server/api/routers/auth-router.ts
@@ -6,48 +6,49 @@ import { createUser, getUser } from "../helpers/auth/user";
 const authRouter = express.Router({ mergeParams: true });
 
 authRouter.post("/register", async (req, res) => {
-    const { username, password } = req.body.newUser;
+	const { username, password } = req.body.newUser;
 
-    const [existingUser] = await getUser(username);
+	const [existingUser] = await getUser(username);
 
-    if (existingUser) {
-        res.status(403).json({
-            message: "Username already exists",
-        });
-    } else {
-        // TODO: log user in after inserting `user` row into database
-        const [newUser] = await createUser({ username, password });
-        res.json({ newUser });
-    }
+	if (existingUser) {
+		res.status(403).json({
+			message: "Username already exists",
+		});
+	} else {
+		// TODO: log user in after inserting `user` row into database
+		const [newUser] = await createUser({ username, password });
+		res.json({ newUser });
+	}
 });
 
 authRouter.post("/login", passport.authenticate("local"), (req, res) => {
-    const { username, created_at } = req.user as any;
-    const userFieldsForClient = {
-        // @todo feat/auth: this should become a type shared with frontend so we can use it as axios response type
-        username,
-        createdAt: created_at,
-    };
+	const { username, created_at } = req.user as any;
+	const userFieldsForClient = {
+		// @todo feat/auth: this should become a type shared with frontend so we can use it as axios response type
+		username,
+		createdAt: created_at,
+	};
 
-    res.json({ ...userFieldsForClient });
+	res.json({ ...userFieldsForClient });
 });
 
 authRouter.get("/me", (req, res) => {
-    if (req.isAuthenticated() && req.user) {
-        res.send(req.user);
-    } else {
-        res.status(401).send("Not authenticated");
-    }
+	if (req.isAuthenticated() && req.user) {
+		const { username } = req.user as any;
+		res.json({ username });
+	} else {
+		res.status(401).send("Not authenticated");
+	}
 });
 
 authRouter.post("/logout", (req, res) => {
-    req.session.destroy(() => {
-        req.logOut();
-        res.json({
-            success: true,
-            message: "Logged out successfully.",
-        });
-    });
+	req.session.destroy(() => {
+		req.logOut();
+		res.json({
+			success: true,
+			message: "Logged out successfully.",
+		});
+	});
 });
 
 export default authRouter;

--- a/server/api/routers/auth-router.ts
+++ b/server/api/routers/auth-router.ts
@@ -37,7 +37,7 @@ authRouter.get("/me", (req, res) => {
 		const { username } = req.user as any;
 		res.json({ username });
 	} else {
-		res.status(401).send("Not authenticated");
+		res.status(401).json({ message: "Not authenticated" });
 	}
 });
 

--- a/server/price-action/lib/polygon/axios-instance.ts
+++ b/server/price-action/lib/polygon/axios-instance.ts
@@ -1,15 +1,16 @@
 import axios from "axios";
 import { config } from "dotenv";
+
 config();
 
 const { POLYGON_KEY } = process.env;
 
 // create an axios instance with authentication header bearer token
 const axiosInstance = axios.create({
-    baseURL: "https://api.polygon.io",
-    headers: {
-        Authorization: `Bearer ${POLYGON_KEY}`,
-    },
+	baseURL: "https://api.polygon.io",
+	headers: {
+		Authorization: `Bearer ${POLYGON_KEY}`,
+	},
 });
 
 export default axiosInstance;


### PR DESCRIPTION
- Create an Axios instance to use throughout the application with a few defaults (`baseURL`, `withCredentials`, and always pass a `username` query param if there is a user in client state).

- Create a `useReconcileUser` hook that, on App mount, GETs `/auth/me` and updates client-side user based on the response.

- `/auth/me` now calls `res.json` instead of `res.send` if there is no authenticated user.

- Run prettier on a bunch of files.