### PR TITLE
Middleware: skip isAllowed middleware in dev environment

### DIFF
--- a/server/api/helpers/middleware/is-allowed.ts
+++ b/server/api/helpers/middleware/is-allowed.ts
@@ -1,6 +1,10 @@
 import { Request, Response } from "express";
 
 export function isAllowed(req: Request, res: Response, next: (args?: any) => any) {
+	if (process.env.NODE_ENV === "development") {
+		return next();
+	}
+
 	// @ts-ignore
 	if (!req.user?.username || !req.body?.username) {
 		res.json({


### PR DESCRIPTION
See title.

Another implementation would be to only call e.g. `tradeRouter.use(isAllowed)` if in development environment, but in the case that the middleware is used across multiple routers, we'd have to do that multiple times, whereas currently it only has to be done once inside the middleware function itself.