### PR TITLE
useRegister: use Axios instance and implement Sentry messages

### DIFF
--- a/client/src/components/Authentication/Register/useRegister.ts
+++ b/client/src/components/Authentication/Register/useRegister.ts
@@ -24,7 +24,7 @@ export function useRegister() {
 	const [newUser, setNewUser] = useState<NewUser>({
 		username: null,
 		password: null,
-		repeatPassword: null,
+		repeatPassword: null
 	});
 
 	// used to flash a message, e.g. 'Username already exists' or 'password
@@ -40,7 +40,7 @@ export function useRegister() {
 			if (isValidNewUser) {
 				try {
 					const { data } = await axiosInstance.post("auth/register", {
-						newUser,
+						newUser
 					});
 
 					const { username } = data.newUser;
@@ -56,8 +56,8 @@ export function useRegister() {
 							extra: {
 								filename: "useRegister",
 								error: e,
-								isAxiosError: axios.isAxiosError,
-							},
+								isAxiosError: axios.isAxiosError(e)
+							}
 						});
 						return setMessage(e.message);
 					}
@@ -68,8 +68,8 @@ export function useRegister() {
 						{
 							extra: {
 								file: "useRegister",
-								error: e,
-							},
+								error: e
+							}
 						}
 					);
 				}
@@ -81,12 +81,12 @@ export function useRegister() {
 	// onChange handler for username, password and repeatPassword inputs
 	function onChange(e: React.ChangeEvent<HTMLInputElement>) {
 		const { name, value } = e.target;
-		setNewUser((current) => ({ ...current, [name]: value }));
+		setNewUser(current => ({ ...current, [name]: value }));
 	}
 
 	return {
 		onChange,
 		onSubmit,
-		message,
+		message
 	} as const;
 }


### PR DESCRIPTION
### Implements the following:
- [x] use our Axios instance for `POST auth/register` request
- [x] trigger Sentry messages when the `onSubmit` function encounters an error