### PR TITLE
`price-action`: run backup scripts from shell on database container initialization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ node_modules
 
 /server/**/*.rest
 /server/**/*.csv
+
+/server/**/*backup*

--- a/_containers/docker-compose.dev.yml
+++ b/_containers/docker-compose.dev.yml
@@ -16,6 +16,7 @@ services:
         volumes:
             - ./pg-data:/var/lib/postgresql/data
             - ../server/price-action/database-setup:/docker-entrypoint-initdb.d
+            - ../server/price-action/database-backups:/psql-backups
         ports:
             - "5432:5432"
 

--- a/server/price-action/database-setup/5_restore.sh
+++ b/server/price-action/database-setup/5_restore.sh
@@ -1,0 +1,1 @@
+pg_restore -U postgres -d trade -F c psql-backups/5_backup_1d.sql


### PR DESCRIPTION
- update `docker-compose.dev.yml` to add a postgres backups folder + volume, and run a shell script from this folder on database initialization (only if database doesn't exist yet.
  - note that backups will typically be quite large, so the folder currently doesn't contain anything on Git. I'm just running a 1-man project here, so there's no point in generalizing this yet. Manually throw any backups in here whenever we need to restore from them, for now.
  - script only runs one hardcoded `pg_restore` now. This should probably be generalized to at least detect whether or not there are any files to run.