### PR TITLE
`fix`: import and use fetchSnapshotWithLimiter instead of fetchSnapshot

### DIFF
--- a/server/api/routers/dev-router.ts
+++ b/server/api/routers/dev-router.ts
@@ -11,10 +11,7 @@ import {
 	fetchAndInsertMaxOneMinuteData,
 	fetchMaxOneMinuteData,
 } from "../../price-action/database/_dev/polygon/max-1m-query";
-import {
-	fetchSnapshot,
-	fetchSnapshotWithLimiter,
-} from "../../price-action/lib/polygon/requests/snapshot/fetch";
+import { fetchSnapshotWithLimiter } from "../../price-action/lib/polygon/requests/snapshot/fetch";
 import { fetchAndInsertSnapshot } from "../../price-action/lib/polygon/requests/snapshot/insert";
 import { rateLimiter } from "../../price-action/store/rate-limit";
 import { snapshotStore } from "../../price-action/store/snapshot-dates";
@@ -32,7 +29,7 @@ dayjs.extend(timezone);
 export const devRouter = express.Router({ mergeParams: true });
 
 devRouter.get("/daily/all", async (req, res) => {
-	const response = await fetchSnapshot({ date: "2021-12-13" });
+	const response = await fetchSnapshotWithLimiter({ date: "2021-12-13" });
 	res.json({ response });
 });
 
@@ -139,7 +136,7 @@ devRouter.get("/trades-with-tickets", async (req, res) => {
 });
 
 devRouter.get("/snapshot/raw", async (req, res) => {
-	const response = await fetchSnapshot({ date: "2022-04-12" });
+	const response = await fetchSnapshotWithLimiter({ date: "2022-04-12" });
 
 	res.json({ response });
 });

--- a/server/price-action/lib/polygon/requests/snapshot/insert.ts
+++ b/server/price-action/lib/polygon/requests/snapshot/insert.ts
@@ -8,7 +8,7 @@ import {
 	priceActionFields,
 	priceActionFieldsString,
 } from "../../../constants/fields";
-import { fetchSnapshot } from "./fetch";
+import { fetchSnapshotWithLimiter } from "./fetch";
 import { snapshotToPriceAction } from "./transform";
 
 /**
@@ -46,7 +46,7 @@ export async function fetchAndInsertSnapshot(date: DateDayjsOrString) {
 	// Check if snapshot was already fetched previously.
 	if (await snapshotStore.exists(date)) return;
 
-	const rawResponse = await fetchSnapshot({ date });
+	const rawResponse = await fetchSnapshotWithLimiter({ date });
 
 	const priceActionObjects = snapshotToPriceAction(rawResponse);
 	if (!priceActionObjects.length) return;


### PR DESCRIPTION
`fetchSnapshot` is only used in the file in which it's declared, but we should never use this function without using the rate limiting functionality. I already changed the functionality, but I forgot to change the usage in a few places.