### PR TITLE
Aggregates: force valid start date, add invalid-data Sentry messages

### DIFF
--- a/server/price-action/database/_dev/polygon/max-1m-query.ts
+++ b/server/price-action/database/_dev/polygon/max-1m-query.ts
@@ -41,7 +41,13 @@ export async function fetchAndInsertMaxOneMinuteData({
 	ticker: string;
 	to?: DateDayjsOrString;
 }) {
-	const [start, end] = nMarketDayRange({ n: maxDaysPerQuery, end: to });
+	// eslint-disable-next-line prefer-const
+	let [start, end] = nMarketDayRange({ n: maxDaysPerQuery, end: to });
+	const twoYearsAgo = dayjs(start).add(-2, "year").add(1, "day");
+
+	if (unixMillis(start) < unixMillis(twoYearsAgo)) {
+		start = formatYMD(twoYearsAgo);
+	}
 
 	try {
 		return await fetchAndInsertAggregate({

--- a/server/price-action/database/_dev/polygon/max-1m-query.ts
+++ b/server/price-action/database/_dev/polygon/max-1m-query.ts
@@ -1,6 +1,9 @@
+import dayjs from "dayjs";
 import { DateDayjsOrString } from "../../../../types/date.types";
 import { fetchAggregateWithLimiter } from "../../../lib/polygon/requests/aggregate/fetch";
 import { fetchAndInsertAggregate } from "../../../lib/polygon/requests/aggregate/insert";
+import { unixMillis } from "../../../lib/time/date-manipulation";
+import { formatYMD } from "../../../lib/time/format-YMD";
 import { nMarketDayRange } from "../../../lib/time/market-day-range";
 
 const maxDaysPerQuery = Math.floor(50_000 / (16 * 60));
@@ -12,7 +15,13 @@ export async function fetchMaxOneMinuteData({
 	ticker: string;
 	to?: DateDayjsOrString;
 }) {
-	const [start, end] = nMarketDayRange({ n: maxDaysPerQuery, end: to });
+	// eslint-disable-next-line prefer-const
+	let [start, end] = nMarketDayRange({ n: maxDaysPerQuery, end: to });
+	const twoYearsAgo = dayjs().startOf("day").add(-2, "year").add(1, "day");
+
+	if (unixMillis(start) < unixMillis(twoYearsAgo)) {
+		start = formatYMD(twoYearsAgo);
+	}
 
 	const rawResponse = await fetchAggregateWithLimiter({
 		ticker,

--- a/server/price-action/lib/polygon/axios-instance.ts
+++ b/server/price-action/lib/polygon/axios-instance.ts
@@ -1,3 +1,4 @@
+import { captureMessage } from "@sentry/node";
 import axios from "axios";
 import { config } from "dotenv";
 
@@ -11,4 +12,15 @@ export const axiosPolygon = axios.create({
 	headers: {
 		Authorization: `Bearer ${POLYGON_KEY}`,
 	},
+});
+
+/** Send a Sentry message if we hit Polygon's rate limit. */
+axiosPolygon.interceptors.response.use((response) => {
+	if (response.status === 429) {
+		const message = "Reached Polygon rate limit";
+		captureMessage(message, { extra: { response } });
+		return Promise.reject(message);
+	}
+
+	return response;
 });

--- a/server/price-action/lib/polygon/requests/aggregate/fetch.ts
+++ b/server/price-action/lib/polygon/requests/aggregate/fetch.ts
@@ -52,11 +52,15 @@ async function fetchTickerAggregate({
 	});
 
 	try {
-		const { data } = await axiosPolygon.get<PolygonAggregateResponse>(url, {
+		const response = await axiosPolygon.get<PolygonAggregateResponse>(url, {
 			params: { limit, sort },
 		});
 
-		return data;
+		if (response.data) {
+			return response.data;
+		}
+
+		throw new Error("No response data returned for aggregate fetch request.");
 	} catch (e) {
 		console.error(e);
 	}

--- a/server/price-action/lib/polygon/requests/aggregate/insert.ts
+++ b/server/price-action/lib/polygon/requests/aggregate/insert.ts
@@ -104,6 +104,8 @@ export async function fetchAndInsertAggregate({
 				arguments,
 			},
 		});
+
+		return;
 	}
 
 	const priceActionObjects = aggregateToPriceAction(rawResponse);

--- a/server/price-action/lib/polygon/requests/aggregate/insert.ts
+++ b/server/price-action/lib/polygon/requests/aggregate/insert.ts
@@ -96,6 +96,16 @@ export async function fetchAndInsertAggregate({
 		multiplier: 1,
 	});
 
+	if (!rawResponse?.results) {
+		captureMessage("Received aggregate response without `results`.", {
+			extra: {
+				rawResponse,
+				// eslint-disable-next-line prefer-rest-params
+				arguments,
+			},
+		});
+	}
+
 	const priceActionObjects = aggregateToPriceAction(rawResponse);
 	const priceActionArrays = priceActionObjects.map((obj) =>
 		objectToArray(obj, priceActionFields)


### PR DESCRIPTION
We might receive empty responses from Polygon's aggregate endpoint if we attempt to fetch data for at least one date out of our permitted range (can only go back two years on a free Polygon plan, for example).

- [x] set minimum `start` date of _today - 2 years + 1 day_ for Polygon aggregate GET requests
- [x] send messages to Sentry in a few cases:
  - [x] we've hit Polygon's rate limit
  - [x] we got a valid Polygon aggregate response with 0 results
  - [x] we got an Axios response without a `data` field.