### PR TITLE
Implement `queueRouter` to group queue-related API endpoints

### DIFF
--- a/server/api/routers/dev-router.ts
+++ b/server/api/routers/dev-router.ts
@@ -10,7 +10,6 @@ import { fetchSnapshotWithLimiter } from "../../price-action/lib/polygon/request
 import { writeAggregateTickerDateTuplesToFetchToFile } from "../../price-action/lib/queue/aggregate/aggregate-backlog";
 import { queueAggregateBacklog } from "../../price-action/lib/queue/aggregate/queue-backlog";
 import { polygonQueue } from "../../price-action/lib/queue/polygon-queue";
-import { addSnapshotFetchJobs } from "../../price-action/lib/queue/snapshot/add-fetch-job";
 import { redisClient } from "../../store/redis-client";
 import { snapshotRouter } from "./snapshot-router";
 
@@ -57,10 +56,6 @@ devRouter.get("/aggregate-backlog/queue", async (req, res) => {
 	} else {
 		res.json({ jobs: await polygonQueue.getJobs() });
 	}
-});
-
-devRouter.get("/queue-snapshot-fetch-manually", async (req, res) => {
-	res.json({ addedJobs: await addSnapshotFetchJobs(["2022-01-22"]) });
 });
 
 devRouter.get("/snapshot/raw/:date", async (req, res) => {

--- a/server/api/routers/dev-router.ts
+++ b/server/api/routers/dev-router.ts
@@ -9,10 +9,7 @@ import { getDailyMostActive } from "../../price-action/database/queries/most-act
 import { fetchSnapshotWithLimiter } from "../../price-action/lib/polygon/requests/snapshot/fetch";
 import { writeAggregateTickerDateTuplesToFetchToFile } from "../../price-action/lib/queue/aggregate/aggregate-backlog";
 import { queueAggregateBacklog } from "../../price-action/lib/queue/aggregate/queue-backlog";
-import {
-	listPolygonQueueJobs,
-	polygonQueue,
-} from "../../price-action/lib/queue/polygon-queue";
+import { polygonQueue } from "../../price-action/lib/queue/polygon-queue";
 import { addSnapshotFetchJobs } from "../../price-action/lib/queue/snapshot/add-fetch-job";
 import { redisClient } from "../../store/redis-client";
 import { snapshotRouter } from "./snapshot-router";
@@ -69,16 +66,6 @@ devRouter.get("/queue-snapshot-fetch-manually", async (req, res) => {
 devRouter.get("/snapshot/raw/:date", async (req, res) => {
 	res.json({
 		response: await fetchSnapshotWithLimiter({ date: req.params.date }),
-	});
-});
-
-devRouter.get("/queue/polygon/jobs", async (req, res) => {
-	res.json({ jobs: await listPolygonQueueJobs() });
-});
-
-devRouter.get("/queue/polygon/jobs/count/delayed", async (req, res) => {
-	res.json({
-		delayedJobCount: await polygonQueue.getJobCountByTypes("delayed"),
 	});
 });
 

--- a/server/api/routers/queue-router.ts
+++ b/server/api/routers/queue-router.ts
@@ -8,6 +8,7 @@ import {
 import { addSnapshotFetchJobs } from "../../price-action/lib/queue/snapshot/add-fetch-job";
 import { formatYMD } from "../../price-action/lib/time/format-YMD";
 
+// TODO: add middleware to only allow admins to access these endpoints
 export const queueRouter = Router({ mergeParams: true });
 
 /** Check whether `jobType` is one of the job types we care about. */

--- a/server/api/routers/queue-router.ts
+++ b/server/api/routers/queue-router.ts
@@ -1,0 +1,3 @@
+import { Router } from "express";
+
+export const queueRouter = Router({ mergeParams: true });

--- a/server/api/routers/queue-router.ts
+++ b/server/api/routers/queue-router.ts
@@ -1,3 +1,31 @@
 import { Router } from "express";
+import {
+	listPolygonQueueJobs,
+	polygonQueue,
+} from "../../price-action/lib/queue/polygon-queue";
 
 export const queueRouter = Router({ mergeParams: true });
+
+/** Get all jobs tagged 'delayed' from polygonQueue. */
+queueRouter.get("/queue/polygon/jobs/count/delayed", async (req, res) => {
+	res.json({
+		delayedJobCount: await polygonQueue.getJobCountByTypes("delayed"),
+	});
+});
+
+/** Fetch counts and data for a few types of jobs. */
+queueRouter.get("/queue/polygon/jobs", async (req, res) => {
+	res.json({ jobs: await listPolygonQueueJobs() });
+});
+
+/** Get data for the job matching `jobId` */
+queueRouter.get("/polygon/job/:id", async (req, res) => {
+	const jobId = req.params.id;
+	const job = await polygonQueue.getJob(jobId);
+
+	if (!job) {
+		res.json({ message: `No job found with id ${jobId}` });
+	} else {
+		res.json({ job });
+	}
+});

--- a/server/index.ts
+++ b/server/index.ts
@@ -10,6 +10,7 @@ import { getUser } from "./api/helpers/auth/user";
 import { logRequests } from "./api/helpers/middleware/log-requests";
 import authRouter from "./api/routers/auth-router";
 import { priceActionRouter } from "./api/routers/price-action-router";
+import { queueRouter } from "./api/routers/queue-router";
 import { tradeRouter } from "./api/routers/trade-router";
 import { polygonSnapshotFetchWorker } from "./price-action/lib/queue/polygon-queue";
 import { redisSession, startRedis } from "./store/redis-client";
@@ -89,6 +90,7 @@ async function main() {
 	app.use("/auth", authRouter);
 	app.use("/t", tradeRouter);
 	app.use("/p", priceActionRouter);
+	app.use("/q", queueRouter);
 
 	app.get("/", (req, res) => {
 		res.json({ message: "/ GET successful" });

--- a/server/price-action/lib/queue/polygon-queue.ts
+++ b/server/price-action/lib/queue/polygon-queue.ts
@@ -110,8 +110,13 @@ export const polygonSnapshotFetchWorker = new Worker(
 	}
 );
 
+/** Get data (and counts) for active, completed, failed and delayed jobs. */
 export async function listPolygonQueueJobs() {
 	return {
+		active: {
+			count: await polygonQueue.getActiveCount(),
+			jobs: await polygonQueue.getActive(),
+		},
 		completed: {
 			count: await polygonQueue.getCompletedCount(),
 			jobs: await polygonQueue.getCompleted(),
@@ -124,6 +129,5 @@ export async function listPolygonQueueJobs() {
 			count: await polygonQueue.getDelayedCount(),
 			jobs: await polygonQueue.getDelayed(),
 		},
-		jobs: await polygonQueue.getJobs(),
 	};
 }


### PR DESCRIPTION
- [x] set up a separate router for queue-related requests. 
- [x] extend `/polygon/jobs/count/...` endpoint to allow user-specified job type (from a selected subset of all possible job types)
- [x] add an endpoint to GET job data for a given `jobId`
- [x] in addition to completed, delayed, failed jobs, also list active jobs in `jobs` endpoint

For the future:
- [ ] protect queueRouter endpoints -- only allow admins to access
- [ ] create endpoints for 