### PR TITLE
`NewTickets`: refine UX

### DIFF
--- a/client/src/components/NewTicket/NewTickets/NewTicket.style.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTicket.style.tsx
@@ -2,9 +2,9 @@ import styled, { css } from "styled-components";
 
 const deleteButtonWidth = "2.5rem";
 
-export const StyledNewTicket = styled.fieldset<{ empty?: boolean }>`
+export const StyledNewTicket = styled.fieldset<{ required?: boolean }>`
 	${(p) =>
-		p.empty &&
+		!p.required &&
 		css`
 			transform: translateZ(0);
 			&:not(:hover) {
@@ -44,15 +44,17 @@ export const StyledNewTicketDeleteButton = styled.button`
 	height: ${deleteButtonSize};
 	line-height: 100%;
 
-	border-radius: 50%;
-
 	transition: color 35ms ease-in, transform 50ms ease-out;
 
 	&:hover,
+	&:focus,
 	&:active {
-		color: red;
-		font-weight: 500;
-		transform: scale(1.4);
+		svg {
+			color: red;
+			font-weight: 500;
+			transform: scale(1.4);
+			outline: 1px solid #eee;
+		}
 	}
 
 	animation: 100ms ease-out slide-in;

--- a/client/src/components/NewTicket/NewTickets/NewTicket.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTicket.tsx
@@ -128,13 +128,12 @@ const NewTicket = ({
 
 			{/* ticker field */}
 			<NewTicketInput
-				required={hasFilledInFields}
+				{...sharedInputProps}
 				$size="small"
 				title="Ticker"
 				name="ticker"
 				defaultValue={ticket.ticker}
 				placeholder={getPlaceholder("ticker")}
-				onChange={onChange}
 			/>
 
 			{/* price field */}

--- a/client/src/components/NewTicket/NewTickets/NewTicket.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTicket.tsx
@@ -91,11 +91,9 @@ const NewTicket = ({
 
 	return (
 		<StyledNewTicket required={isRequired} {...eventHandlers}>
-			{/* action buttons */}
 			{/* TODO: I don't like that these are just in a span. Has to be a more semantic way to do this. */}
 			<span>{actionButtons}</span>
 
-			{/* ticker field */}
 			<NewTicketInput
 				{...sharedInputProps}
 				$size="small"
@@ -105,7 +103,6 @@ const NewTicket = ({
 				placeholder={getPlaceholder("ticker")}
 			/>
 
-			{/* price field */}
 			<NewTicketInput
 				{...sharedInputProps}
 				$size="small"
@@ -118,7 +115,6 @@ const NewTicket = ({
 				placeholder={getPlaceholder("price")}
 			/>
 
-			{/* quantity field */}
 			<NewTicketInput
 				{...sharedInputProps}
 				$size="small"
@@ -131,7 +127,6 @@ const NewTicket = ({
 				placeholder={getPlaceholder("quantity")}
 			/>
 
-			{/* date field */}
 			<NewTicketInput
 				required={isRequired}
 				$size="large"
@@ -141,7 +136,6 @@ const NewTicket = ({
 				defaultValue={ticket.date}
 			/>
 
-			{/* time field */}
 			<NewTicketInput
 				required={isRequired}
 				title="Time of day (market time)"

--- a/client/src/components/NewTicket/NewTickets/NewTicket.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTicket.tsx
@@ -157,7 +157,7 @@ const NewTicket = ({
 						deleteTicket(ticketIndex);
 					}}
 				>
-					<BsX overflow={"visible"} />
+					<BsX />
 				</StyledNewTicketDeleteButton>
 			)}
 		</StyledNewTicket>

--- a/client/src/components/NewTicket/NewTickets/NewTicket.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTicket.tsx
@@ -48,25 +48,21 @@ const NewTicket = ({
 
 	const actionButtons = useMemo(
 		() =>
-			actions.map((action: TradeAction) => {
-				const active = ticket?.action === action;
-
-				return (
-					<TradeActionButton
-						// The required prop is only used to display a border.
-						// If there is already a ticket.action value, we don't want
-						// the 'required'-specific border.
-						required={isRequired && !ticket.action}
-						index={ticketIndex}
-						key={action}
-						action={action}
-						active={active}
-						onClick={() => {
-							setAction(ticketIndex, action);
-						}}
-					/>
-				);
-			}),
+			actions.map((action: TradeAction) => (
+				<TradeActionButton
+					// The required prop is only used to display a border.
+					// If there is already a ticket.action value, we don't want
+					// the 'required'-specific border.
+					required={isRequired && !ticket.action}
+					index={ticketIndex}
+					key={action}
+					action={action}
+					active={ticket?.action === action}
+					onClick={() => {
+						setAction(ticketIndex, action);
+					}}
+				/>
+			)),
 		[ticket, isRequired]
 	);
 

--- a/client/src/components/NewTicket/NewTickets/NewTickets.style.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTickets.style.tsx
@@ -36,9 +36,11 @@ export const NewTicketsButton = styled.input<{ round?: boolean }>`
 
 	transition: all 75ms ease-out;
 
-	&:hover {
-		box-shadow: 0 4px 0 -2px lightgrey;
-		transform: translateY(-2px);
+	&:not(:disabled) {
+		&:hover {
+			box-shadow: 0 4px 0 -2px lightgrey;
+			transform: translateY(-2px);
+		}
 	}
 `;
 

--- a/client/src/components/NewTicket/NewTickets/NewTickets.style.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTickets.style.tsx
@@ -11,12 +11,15 @@ export const NewTicketsButtonBar = styled.span`
 	}
 `;
 
+const roundButtonSize = "25px;";
+
 export const NewTicketsButton = styled.input<{ round?: boolean }>`
+	height: ${roundButtonSize};
 	${(p) =>
 		p.round
 			? css`
-					width: 25px;
-					height: 25px;
+					width: ${roundButtonSize};
+					height: ${roundButtonSize};
 					border-radius: 50%;
 					justify-content: center;
 					text-align: center;
@@ -28,7 +31,7 @@ export const NewTicketsButton = styled.input<{ round?: boolean }>`
 					padding: ${(p) => p.theme.padding.wide.button.tiny};
 			  `}
 
-	display: inline-flex;
+	display: flex;
 	background-color: transparent;
 	font-size: ${(p) => p.theme.font.tiny};
 

--- a/client/src/components/NewTicket/NewTickets/NewTickets.style.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTickets.style.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from "styled-components";
 
-export const StyledNewTicketsButtonBar = styled.span`
+export const NewTicketsButtonBar = styled.span`
 	display: flex;
 	justify-content: space-between;
 
@@ -11,7 +11,7 @@ export const StyledNewTicketsButtonBar = styled.span`
 	}
 `;
 
-export const StyledNewTicketsButton = styled.input<{ round?: boolean }>`
+export const NewTicketsButton = styled.input<{ round?: boolean }>`
 	${(p) =>
 		p.round
 			? css`
@@ -42,7 +42,7 @@ export const StyledNewTicketsButton = styled.input<{ round?: boolean }>`
 	}
 `;
 
-export const StyledNewTicketsButtons = styled.div`
+export const NewTicketsButtons = styled.div`
 	display: block;
 	position: sticky;
 	z-index: 2;
@@ -52,7 +52,7 @@ export const StyledNewTicketsButtons = styled.div`
 	gap: ${({ theme }) => theme.padding.tiny};
 `;
 
-export const StyledNewTickets = styled.form`
+export const NewTickets = styled.form`
 	display: block;
 	margin: 0 auto;
 	max-width: max-content;
@@ -63,7 +63,7 @@ export const StyledNewTickets = styled.form`
 	box-shadow: 0 0 0.2rem 0 #ccc;
 `;
 
-export const StyledNewTicketsTitle = styled.h1`
+export const NewTicketsTitle = styled.h1`
 	display: block;
 	width: max-content;
 	position: relative;
@@ -90,7 +90,7 @@ export const StyledNewTicketsTitle = styled.h1`
 	}
 `;
 
-export const StyledNewTicketsSubtitle = styled.h3`
+export const NewTicketsSubtitle = styled.h3`
 	font-size: ${(p) => p.theme.font.medium};
 	word-wrap: break-word;
 	color: #aaa;
@@ -103,6 +103,6 @@ export const StyledNewTicketsSubtitle = styled.h3`
 	margin-bottom: ${(p) => p.theme.padding.tiny};
 `;
 
-export const StyledTickets = styled.section`
+export const Tickets = styled.section`
 	margin: ${(p) => p.theme.padding.large} 0;
 `;

--- a/client/src/components/NewTicket/NewTickets/NewTickets.style.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTickets.style.tsx
@@ -13,7 +13,10 @@ export const NewTicketsButtonBar = styled.span`
 
 const roundButtonSize = "25px;";
 
-export const NewTicketsButton = styled.input<{ round?: boolean }>`
+export const NewTicketsButton = styled.input<{
+	round?: boolean;
+	isCTA?: boolean;
+}>`
 	height: ${roundButtonSize};
 	${(p) =>
 		p.round
@@ -31,17 +34,25 @@ export const NewTicketsButton = styled.input<{ round?: boolean }>`
 					padding: ${(p) => p.theme.padding.wide.button.tiny};
 			  `}
 
-	display: flex;
+	display: inline-flex;
 	background-color: transparent;
 	font-size: ${(p) => p.theme.font.tiny};
 
 	border: 2px solid ${(p) => p.theme.colors.grey.light};
 
+	${(p) =>
+		p.isCTA &&
+		css`
+			border-color: ${p.theme.colors.green.primary};
+			background-color: ${p.theme.colors.green.primary};
+			color: white;
+		`}
+
 	transition: all 75ms ease-out;
 
 	&:not(:disabled) {
 		&:hover {
-			box-shadow: 0 4px 0 -2px lightgrey;
+			box-shadow: 0 4px 0 -2px ${(p) => (p.isCTA ? p.theme.colors.green.primary : "lightgrey")};
 			transform: translateY(-2px);
 		}
 	}

--- a/client/src/components/NewTicket/NewTickets/NewTickets.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTickets.tsx
@@ -1,4 +1,4 @@
-import { useMemo } from "react";
+import { MouseEvent, useCallback, useMemo } from "react";
 import NewTicket from "./NewTicket";
 import {
 	StyledNewTickets,
@@ -27,6 +27,24 @@ export default function NewTickets() {
 		onSubmit,
 		deleteTicket,
 	} = useNewTickets();
+
+	/**
+	 * Handler for the "Save tickets" button. It only triggers the Preview modal
+	 * if there is at least one valid ticket, otherwise it doesn't do anything.
+	 */
+	const handlePreviewClick = useCallback(
+		(e: MouseEvent<HTMLInputElement>) => {
+			if (validTickets?.length) {
+				setShowSummary(true);
+			}
+		},
+		[validTickets, setShowSummary]
+	);
+
+	/** Handler for the `+` button, which represents "Add `n` ticket rows". */
+	const handleAddClick = (e: MouseEvent<HTMLInputElement>, _: number) => {
+		addTicketRows(_);
+	};
 
 	const ticketElements = useMemo(() => {
 		return tickets.map((ticket, ticketIndex) => {
@@ -64,8 +82,11 @@ export default function NewTickets() {
 				</StyledNewTicketsSubtitle>
 				<StyledTickets>
 					<Buttons
-						addTicketRows={addTicketRows}
-						setShowSummary={setShowSummary}
+						{...{
+							handleAddClick,
+							handlePreviewClick,
+							disabledPreviewButton: !validTickets?.length,
+						}}
 					/>
 					<Header />
 					{ticketElements}
@@ -76,11 +97,16 @@ export default function NewTickets() {
 }
 
 type ButtonProps = {
-	addTicketRows: (_: number) => void;
-	setShowSummary: (_: boolean) => void;
+	handleAddClick: (e: MouseEvent<HTMLInputElement>, _: number) => void;
+	handlePreviewClick: (e: MouseEvent<HTMLInputElement>) => void;
+	disabledPreviewButton?: boolean;
 };
 
-function Buttons({ addTicketRows, setShowSummary }: ButtonProps) {
+function Buttons({
+	handleAddClick,
+	handlePreviewClick,
+	disabledPreviewButton,
+}: ButtonProps) {
 	return (
 		<StyledNewTicketsButtons>
 			<StyledNewTicketsButtonBar>
@@ -90,24 +116,19 @@ function Buttons({ addTicketRows, setShowSummary }: ButtonProps) {
 					<StyledNewTicketsButton
 						type="button"
 						value="Save tickets"
-						onClick={() => {
-							// TODO: only show preview if there is at least one valid
-							// ticket. The best way to do this is probably a function
-							// like maybeShowSummary that only calls setShowSummary if
-							// !!validTickets.length. Then we can pass this function to
-							// this Buttons component without also needing to pass validTickets
-							setShowSummary(true);
-						}}
+						disabled={disabledPreviewButton}
+						onClick={handlePreviewClick}
 					/>
 				</span>
 				<span>
 					<StyledNewTicketsButton
 						round
 						type="button"
-						onClick={() => addTicketRows(3)}
+						onClick={(e) => handleAddClick(e, 3)}
 						value="+"
 						title="Add 3 rows"
 					/>
+					{/* TODO: this button is nonfuctional currently. */}
 					<StyledNewTicketsButton
 						round
 						type="button"

--- a/client/src/components/NewTicket/NewTickets/NewTickets.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTickets.tsx
@@ -1,6 +1,7 @@
 import { MouseEvent, useCallback, useMemo } from "react";
 import NewTicket from "./NewTicket";
 import * as S from "./NewTickets.style";
+import Buttons from "./sub/Buttons";
 import Header from "./sub/Header";
 import TicketSummary from "./TicketSummary";
 import { useNewTickets } from "./useNewTickets";
@@ -77,7 +78,7 @@ export default function NewTickets() {
 						{...{
 							handleAddClick,
 							handlePreviewClick,
-							disabledPreviewButton: !validTickets?.length,
+							previewButtonDisabled: !validTickets?.length,
 						}}
 					/>
 					<Header />
@@ -85,50 +86,5 @@ export default function NewTickets() {
 				</S.Tickets>
 			</S.NewTickets>
 		</>
-	);
-}
-
-type ButtonProps = {
-	handleAddClick: (e: MouseEvent<HTMLInputElement>, _: number) => void;
-	handlePreviewClick: (e: MouseEvent<HTMLInputElement>) => void;
-	disabledPreviewButton?: boolean;
-};
-
-function Buttons({
-	handleAddClick,
-	handlePreviewClick,
-	disabledPreviewButton,
-}: ButtonProps) {
-	return (
-		<S.NewTicketsButtons>
-			<S.NewTicketsButtonBar>
-				<span>
-					{/*   TODO: should become a button with on-hover effect: start as green 
-                     button with arrow, slide text into it on hover */}
-					<S.NewTicketsButton
-						type="button"
-						value="Save tickets"
-						disabled={disabledPreviewButton}
-						onClick={handlePreviewClick}
-					/>
-				</span>
-				<span>
-					<S.NewTicketsButton
-						round
-						type="button"
-						onClick={(e) => handleAddClick(e, 3)}
-						value="+"
-						title="Add 3 rows"
-					/>
-					{/* TODO: this button is nonfuctional currently. */}
-					<S.NewTicketsButton
-						round
-						type="button"
-						value="x"
-						title="Delete empty tickets"
-					/>
-				</span>
-			</S.NewTicketsButtonBar>
-		</S.NewTicketsButtons>
 	);
 }

--- a/client/src/components/NewTicket/NewTickets/NewTickets.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTickets.tsx
@@ -13,9 +13,7 @@ import Header from "./sub/Header";
 import TicketSummary from "./TicketSummary";
 import { useNewTickets } from "./useNewTickets";
 
-/**
- * Form that allows for creation of new trade tickets.
- */
+/** Form that allows for creation of new trade tickets. */
 export default function NewTickets() {
 	const {
 		tickets,
@@ -48,9 +46,9 @@ export default function NewTickets() {
 	return (
 		<>
 			<StyledNewTickets onSubmit={onSubmit}>
-				{/*   
-               Render TicketSummary inside the form, so that any submit buttons 
-               in there trigger this form's onSubmit handler */}
+				{/* Render TicketSummary inside the form, so that any submit buttons in 
+                there trigger this form's onSubmit handler. An alternative would be 
+                to give the form an id `formId`, and use form={formId} */}
 				{showSummary && validTickets?.length > 0 && (
 					<TicketSummary
 						tickets={validTickets}

--- a/client/src/components/NewTicket/NewTickets/NewTickets.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTickets.tsx
@@ -1,4 +1,4 @@
-import { MouseEvent, useCallback, useMemo } from "react";
+import { useMemo } from "react";
 import NewTicket from "./NewTicket";
 import * as S from "./NewTickets.style";
 import Buttons from "./sub/Buttons";
@@ -16,28 +16,11 @@ export default function NewTickets() {
 		setShowSummary,
 		setAction,
 		setField,
-		addTicketRows,
 		onSubmit,
 		deleteTicket,
+		handlePreviewClick,
+		handleAddClick,
 	} = useNewTickets();
-
-	/**
-	 * Handler for the "Save tickets" button. It only triggers the Preview modal
-	 * if there is at least one valid ticket, otherwise it doesn't do anything.
-	 */
-	const handlePreviewClick = useCallback(
-		(e: MouseEvent<HTMLInputElement>) => {
-			if (validTickets?.length) {
-				setShowSummary(true);
-			}
-		},
-		[validTickets, setShowSummary]
-	);
-
-	/** Handler for the `+` button, which represents "Add `n` ticket rows". */
-	const handleAddClick = (e: MouseEvent<HTMLInputElement>, _: number) => {
-		addTicketRows(_);
-	};
 
 	const ticketElements = useMemo(() => {
 		return tickets.map((ticket, ticketIndex) => {

--- a/client/src/components/NewTicket/NewTickets/NewTickets.tsx
+++ b/client/src/components/NewTicket/NewTickets/NewTickets.tsx
@@ -1,14 +1,6 @@
 import { MouseEvent, useCallback, useMemo } from "react";
 import NewTicket from "./NewTicket";
-import {
-	StyledNewTickets,
-	StyledNewTicketsButton,
-	StyledNewTicketsButtonBar,
-	StyledNewTicketsButtons,
-	StyledNewTicketsSubtitle,
-	StyledNewTicketsTitle,
-	StyledTickets,
-} from "./NewTickets.style";
+import * as S from "./NewTickets.style";
 import Header from "./sub/Header";
 import TicketSummary from "./TicketSummary";
 import { useNewTickets } from "./useNewTickets";
@@ -63,7 +55,7 @@ export default function NewTickets() {
 
 	return (
 		<>
-			<StyledNewTickets onSubmit={onSubmit}>
+			<S.NewTickets onSubmit={onSubmit}>
 				{/* Render TicketSummary inside the form, so that any submit buttons in 
                 there trigger this form's onSubmit handler. An alternative would be 
                 to give the form an id `formId`, and use form={formId} */}
@@ -76,11 +68,11 @@ export default function NewTickets() {
 						}}
 					/>
 				)}
-				<StyledNewTicketsTitle>Add new trade tickets</StyledNewTicketsTitle>
-				<StyledNewTicketsSubtitle>
+				<S.NewTicketsTitle>Add new trade tickets</S.NewTicketsTitle>
+				<S.NewTicketsSubtitle>
 					Each ticket describes one buy or sell transaction.
-				</StyledNewTicketsSubtitle>
-				<StyledTickets>
+				</S.NewTicketsSubtitle>
+				<S.Tickets>
 					<Buttons
 						{...{
 							handleAddClick,
@@ -90,8 +82,8 @@ export default function NewTickets() {
 					/>
 					<Header />
 					{ticketElements}
-				</StyledTickets>
-			</StyledNewTickets>
+				</S.Tickets>
+			</S.NewTickets>
 		</>
 	);
 }
@@ -108,12 +100,12 @@ function Buttons({
 	disabledPreviewButton,
 }: ButtonProps) {
 	return (
-		<StyledNewTicketsButtons>
-			<StyledNewTicketsButtonBar>
+		<S.NewTicketsButtons>
+			<S.NewTicketsButtonBar>
 				<span>
 					{/*   TODO: should become a button with on-hover effect: start as green 
                      button with arrow, slide text into it on hover */}
-					<StyledNewTicketsButton
+					<S.NewTicketsButton
 						type="button"
 						value="Save tickets"
 						disabled={disabledPreviewButton}
@@ -121,7 +113,7 @@ function Buttons({
 					/>
 				</span>
 				<span>
-					<StyledNewTicketsButton
+					<S.NewTicketsButton
 						round
 						type="button"
 						onClick={(e) => handleAddClick(e, 3)}
@@ -129,14 +121,14 @@ function Buttons({
 						title="Add 3 rows"
 					/>
 					{/* TODO: this button is nonfuctional currently. */}
-					<StyledNewTicketsButton
+					<S.NewTicketsButton
 						round
 						type="button"
 						value="x"
 						title="Delete empty tickets"
 					/>
 				</span>
-			</StyledNewTicketsButtonBar>
-		</StyledNewTicketsButtons>
+			</S.NewTicketsButtonBar>
+		</S.NewTicketsButtons>
 	);
 }

--- a/client/src/components/NewTicket/NewTickets/helpers/parse-validate.ts
+++ b/client/src/components/NewTicket/NewTickets/helpers/parse-validate.ts
@@ -47,7 +47,7 @@ export function isValidTicket(ticket: ReturnType<typeof parseNewTicketInputs>) {
 
 	// Early return if ticket doesn't have a value for any of the necessary
 	// fields. TODO: this could just be HTML validation
-	if (!ticket || !fields.every((field) => ticket[field] !== undefined)) {
+	if (!ticket || fields.some((field) => !ticket[field])) {
 		return;
 	}
 

--- a/client/src/components/NewTicket/NewTickets/sub/Buttons.tsx
+++ b/client/src/components/NewTicket/NewTickets/sub/Buttons.tsx
@@ -20,6 +20,7 @@ export default function Buttons({
                      button with arrow, slide text into it on hover */}
 					{!previewButtonDisabled ? (
 						<S.NewTicketsButton
+							isCTA
 							type="button"
 							value="Save tickets"
 							disabled={previewButtonDisabled}

--- a/client/src/components/NewTicket/NewTickets/sub/Buttons.tsx
+++ b/client/src/components/NewTicket/NewTickets/sub/Buttons.tsx
@@ -1,0 +1,47 @@
+import { MouseEvent } from "react";
+import * as S from "../NewTickets.style";
+
+type ButtonProps = {
+	handleAddClick: (e: MouseEvent<HTMLInputElement>, _: number) => void;
+	handlePreviewClick: (e: MouseEvent<HTMLInputElement>) => void;
+	previewButtonDisabled?: boolean;
+};
+
+export default function Buttons({
+	handleAddClick,
+	handlePreviewClick,
+	previewButtonDisabled,
+}: ButtonProps) {
+	return (
+		<S.NewTicketsButtons>
+			<S.NewTicketsButtonBar>
+				<span>
+					{/*   TODO: should become a button with on-hover effect: start as green 
+                     button with arrow, slide text into it on hover */}
+					<S.NewTicketsButton
+						type="button"
+						value="Save tickets"
+						disabled={previewButtonDisabled}
+						onClick={handlePreviewClick}
+					/>
+				</span>
+				<span>
+					<S.NewTicketsButton
+						round
+						type="button"
+						onClick={(e) => handleAddClick(e, 3)}
+						value="+"
+						title="Add 3 rows"
+					/>
+					{/* TODO: this button is nonfuctional currently. */}
+					<S.NewTicketsButton
+						round
+						type="button"
+						value="x"
+						title="Delete empty tickets"
+					/>
+				</span>
+			</S.NewTicketsButtonBar>
+		</S.NewTicketsButtons>
+	);
+}

--- a/client/src/components/NewTicket/NewTickets/sub/Buttons.tsx
+++ b/client/src/components/NewTicket/NewTickets/sub/Buttons.tsx
@@ -18,12 +18,16 @@ export default function Buttons({
 				<span>
 					{/*   TODO: should become a button with on-hover effect: start as green 
                      button with arrow, slide text into it on hover */}
-					<S.NewTicketsButton
-						type="button"
-						value="Save tickets"
-						disabled={previewButtonDisabled}
-						onClick={handlePreviewClick}
-					/>
+					{!previewButtonDisabled ? (
+						<S.NewTicketsButton
+							type="button"
+							value="Save tickets"
+							disabled={previewButtonDisabled}
+							onClick={handlePreviewClick}
+						/>
+					) : (
+						<></>
+					)}
 				</span>
 				<span>
 					<S.NewTicketsButton

--- a/client/src/components/NewTicket/NewTickets/useNewTicket.tsx
+++ b/client/src/components/NewTicket/NewTickets/useNewTicket.tsx
@@ -1,14 +1,10 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useMemo, useState } from "react";
 import { RawNewTicket } from "./NewTicket";
 
 export function useNewTicket(ticket: Partial<RawNewTicket>) {
 	const [isHovering, setIsHovering] = useState<boolean>(false);
 	const [isFocused, setIsFocused] = useState<boolean>(false);
 	const [shouldShowDelete, setShouldShowDelete] = useState<boolean>(false);
-
-	useEffect(() => {
-		console.log({ shouldShowDelete });
-	}, [shouldShowDelete]);
 
 	// TODO: combine showDelete and hideDelete into one function
 	const showDelete = () => setShouldShowDelete(true);

--- a/client/src/components/NewTicket/NewTickets/useNewTicket.tsx
+++ b/client/src/components/NewTicket/NewTickets/useNewTicket.tsx
@@ -1,0 +1,77 @@
+import { useCallback, useMemo, useState } from "react";
+import { RawNewTicket } from "./NewTicket";
+
+export function useNewTicket(ticket: Partial<RawNewTicket>) {
+	const [isHovering, setIsHovering] = useState<boolean>(false);
+	const [isFocused, setIsFocused] = useState<boolean>(false);
+	const [shouldShowDelete, setShouldShowDelete] = useState<boolean>(false);
+
+	// TODO: combine showDelete and hideDelete into one function
+	const showDelete = () => setShouldShowDelete(true);
+	const hideDelete = () => setShouldShowDelete(false);
+
+	const hasFilledInFields = useMemo(() => {
+		return "price ticker quantity action"
+			.split(" ")
+			.some(
+				(field) =>
+					field in ticket &&
+					ticket[field] !== undefined &&
+					ticket[field]?.length
+			);
+	}, [ticket]);
+
+	const isRequired = useMemo(() => {
+		return !!(hasFilledInFields || isHovering || isFocused);
+	}, [hasFilledInFields, isHovering, isFocused]);
+
+	/**
+	 * Returns placeholder value if the field is `required` (a field becomes required
+	 * when either the ticket has at least one filled-in field, or when it or one
+	 * of its containing fields is active or being hovered.)
+	 */
+	const getPlaceholder = useCallback(
+		(placeholder: string) => {
+			return isRequired ? placeholder : null;
+		},
+		[isRequired]
+	);
+
+	const handleMouseEnter = () => {
+		showDelete();
+		setIsHovering(true);
+	};
+
+	const handleFocus = (e) => {
+		showDelete();
+		setIsFocused(true);
+	};
+
+	const handleBlur = (e) => {
+		hideDelete();
+		setIsFocused(false);
+	};
+
+	const handleMouseLeave = () => {
+		setIsHovering(false);
+		if (!isFocused) {
+			hideDelete();
+		}
+	};
+
+	const eventHandlers = () => ({
+		onBlur: handleBlur,
+		onMouseEnter: handleMouseEnter,
+		onMouseLeave: handleMouseLeave,
+		onFocus: handleFocus,
+	});
+
+	return {
+		isRequired,
+		getPlaceholder,
+		showDelete,
+		hideDelete,
+		eventHandlers,
+		shouldShowDelete,
+	} as const;
+}

--- a/client/src/components/NewTicket/NewTickets/useNewTicket.tsx
+++ b/client/src/components/NewTicket/NewTickets/useNewTicket.tsx
@@ -1,10 +1,14 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { RawNewTicket } from "./NewTicket";
 
 export function useNewTicket(ticket: Partial<RawNewTicket>) {
 	const [isHovering, setIsHovering] = useState<boolean>(false);
 	const [isFocused, setIsFocused] = useState<boolean>(false);
 	const [shouldShowDelete, setShouldShowDelete] = useState<boolean>(false);
+
+	useEffect(() => {
+		console.log({ shouldShowDelete });
+	}, [shouldShowDelete]);
 
 	// TODO: combine showDelete and hideDelete into one function
 	const showDelete = () => setShouldShowDelete(true);
@@ -59,12 +63,12 @@ export function useNewTicket(ticket: Partial<RawNewTicket>) {
 		}
 	};
 
-	const eventHandlers = () => ({
+	const eventHandlers = {
 		onBlur: handleBlur,
 		onMouseEnter: handleMouseEnter,
 		onMouseLeave: handleMouseLeave,
 		onFocus: handleFocus,
-	});
+	};
 
 	return {
 		isRequired,

--- a/client/src/components/NewTicket/NewTickets/useNewTickets.ts
+++ b/client/src/components/NewTicket/NewTickets/useNewTickets.ts
@@ -3,7 +3,7 @@ import axios from "axios";
 import dayjs from "dayjs";
 import useAxios from "helpers/api/axios-instance";
 import { useAuth } from "hooks/auth/useAuth";
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { MouseEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { SavedTicket } from "types/tickets";
 import { isValidTicket, parseNewTicketInputs } from "./helpers/parse-validate";
 import { RawNewTicket } from "./NewTicket";
@@ -116,6 +116,24 @@ export function useNewTickets() {
 		});
 	}
 
+	/**
+	 * Handler for the "Save tickets" button. It only triggers the Preview modal
+	 * if there is at least one valid ticket, otherwise it doesn't do anything.
+	 */
+	const handlePreviewClick = useCallback(
+		(e: MouseEvent<HTMLInputElement>) => {
+			if (validTickets?.length) {
+				setShowSummary(true);
+			}
+		},
+		[validTickets, setShowSummary]
+	);
+
+	/** Handler for the `+` button, which represents "Add `n` ticket rows". */
+	const handleAddClick = (e: MouseEvent<HTMLInputElement>, _: number) => {
+		addTicketRows(_);
+	};
+
 	return {
 		tickets,
 		validTickets,
@@ -127,5 +145,7 @@ export function useNewTickets() {
 		savedTickets,
 		showSummary,
 		setShowSummary,
+		handleAddClick,
+		handlePreviewClick,
 	} as const;
 }

--- a/client/src/helpers/theme/theme.tsx
+++ b/client/src/helpers/theme/theme.tsx
@@ -10,6 +10,9 @@ export const colors = {
 	text: {
 		secondary: "#e3e3e3",
 	},
+	green: {
+		primary: "forestgreen",
+	},
 };
 
 export const size = {


### PR DESCRIPTION
See #29.

WIP

Implements some UX improvements to the NewTickets component and related subcomponents.

### Implements the following:
- [x] refine conditions for showing NewTicket field placeholders
- [x] add outline style to NewTicket delete button
- [x] disable or hide "Save tickets" button if there aren't any valid tickets in the form yet
- [ ] add hover and active state to `TradeActionButtons`
- [x] adjust styling of "Save tickets" button
  - [ ] consider generalizing these styles to a `CTAButton` Styled component

### Side effects;
- [x] extract functionality for `NewTicket.tsx` to a `useNewTicket` hook
- [x] start using `import * as S from 'path/to/*.style'` so we can get rid of `StyledX` component naming