### PR TITLE
`Sentry`: use environment tag

### DIFF
--- a/client/src/hooks/useSentry.tsx
+++ b/client/src/hooks/useSentry.tsx
@@ -11,7 +11,7 @@ export default function useSentry() {
 			release: process.env.SENTRY_RELEASE,
 			integrations: [new BrowserTracing({ routingInstrumentation })],
 			tracesSampleRate: 1,
-			environment: process.env.APP_ENV,
+			environment: process.env.APP_ENV ?? "dev",
 			autoSessionTracking: false,
 		});
 	}, [routingInstrumentation]);

--- a/client/src/hooks/useSentry.tsx
+++ b/client/src/hooks/useSentry.tsx
@@ -11,6 +11,7 @@ export default function useSentry() {
 			release: process.env.SENTRY_RELEASE,
 			integrations: [new BrowserTracing({ routingInstrumentation })],
 			tracesSampleRate: 1,
+			environment: process.env.APP_ENV,
 			autoSessionTracking: false,
 		});
 	}, [routingInstrumentation]);


### PR DESCRIPTION
Set Sentry environment to `process.env.APP_ENV`. 

Make sure to include this environment variable in `client/.env` (or somewhere else where it's accessible to the client's process.env, like in the `process.env` definition in `client/webpack.config.js`).